### PR TITLE
Resize param is not needed any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,6 @@ python3 main.py -h:
                         2: Detect structure for experimental maps with 4 fold models
                         3: Detect and evaluate structure for experimental maps with 4 fold models
                         4: Detect protein and DNA/RNA with 4 fold models
-  --resize              0: resizing maps with numba optimized (some maps size are not supported); 
-                        1: resizing maps with scipy (relatively slow but support almost all maps).
   -P P                  native structure path (PDB format) for evaluating model's performance (usually not available for real scenarios)
   -M                    Trained model path which saved all the trained models
   --type TYPE           0:simulated map at 6 Å 1: simulated map at 10 Å 2:simulated map at 6-10 Å 3:experimental map
@@ -149,7 +147,6 @@ python3 main.py --mode=0 -F=[Map_path] --type=[Map_Type] --gpu=0 --class=4 --con
 ```
 Here [Map_path] is the cryo-EM map file path in your computer. [Map_Type] should be specified based on your input map type, which will be used to load proper pre-trained model. [contour_level] and [Choose_Fold] only need to be specified for experimental maps.             
 Output will be saved in "Predict_Result/[Map_Type]/[Input_Map_Name]".       
-If the map grid size is smaller than 1, you also need to specify –-resize=1 to resize the grid size in the command line. This will make the program run slower than the default mode. 
 ### 2. Evaluate Performance (only when the correct underlined structure in the map is known)
 #### In the case that you are testing the software with a case, you can check the accuracy of the structure detection by Emap2sec+ by comparing the result with the known structure. This mode cannot be used in real scenarios where the native structure is not available. We usually use the mode to evaluate Emap2sec+ performance on testing dataset with known structures to verify its performance. This mode is also useful to measure the difference of the detected structure by Emap2sec+ with the structure currently assigned to the EM map.
 ```
@@ -184,7 +181,6 @@ python3 main.py --mode=0 -F=[Map_path] -M=[model_path] --type=3 --gpu=0 --class=
 ```
 Here [Map_path] is the cryo-EM map file path in your computer. [model_path] should be specified based on the trained model location downloaded from [kiharalab](https://kiharalab.org/emsuites/emap2secplus_model/nocontour_best_model.tar.gz). [Choose_Fold] is used to specify the fold model used for inference.             
 Output will be saved in "Predict_Result/[Map_Type]/[Input_Map_Name]".       
-If the map grid size is smaller than 1, you also need to specify –-resize=1 to resize the grid size in the command line. This will make the program run slower than the default mode. 
 #### 6.2 Detect Structures with 4 fold networks
 ```
 python3 main.py --mode=2 -F=[Map_path] -M=[model_path] --type=3 --gpu=0 --class=4 --contour=0
@@ -222,7 +218,7 @@ Command line
 ```
 python3 main.py --mode=0 -F=test_example/SIMU10/5T5K.mrc --type=1 --gpu=0 --class=4 
 ```
-If the map grid size is smaller than 1, you also need to specify –-resize=1 to resize the grid size in the command line. This will make the command run slower than the default mode. The example input map is included in [5T5K](https://kiharalab.org/github_data/emap2secplus_data/SIMU10).Our detailed results are saved in [5T5K_Result](https://kiharalab.org/github_data/emap2secplus_predict_example/SIMU10).
+The example input map is included in [5T5K](https://kiharalab.org/github_data/emap2secplus_data/SIMU10).Our detailed results are saved in [5T5K_Result](https://kiharalab.org/github_data/emap2secplus_predict_example/SIMU10).
 
 #### 2 Visualize Result
 Results are saved in Predict_Result/SIMU10/[Input_Map_Name]. Phase 1 and Phase 2 visualization results (Pymol sessions) are saved in “Phase1” and “Phase2” sub-directory, respectively. You will find generated *.pml files generated to visualize. Please use “pymol -u *.pml” to visualize the final structure detection result. If you want to only see very confident detection results, run “pymol -u *C.pml” using another visualization file named "*C.pml", which only includes confident detections with a probability>=0.9.
@@ -256,7 +252,7 @@ Command line:
 ```
 python3 main.py --mode=0 -F=test_example/REAL/6BJS.mrc --type=3 --gpu=0 --class=4 --fold=3 -–contour=0.006 
 ```
-If the map grid size is smaller than 1, you also need to specify –-resize=1 to resize the grid size in the command line. This will make the command run slower than the default mode. The example input map is included in [6BJS](https://kiharalab.org/github_data/emap2secplus_data/REAL), which is in the fold 3 testing dataset. Our detailed results are saved in [6BJS_Result](https://kiharalab.org/github_data/emap2secplus_predict_example/REAL).
+The example input map is included in [6BJS](https://kiharalab.org/github_data/emap2secplus_data/REAL), which is in the fold 3 testing dataset. Our detailed results are saved in [6BJS_Result](https://kiharalab.org/github_data/emap2secplus_predict_example/REAL).
 
 #### 2 Visualize Result
 Results are saved in Predict_Result/REAL/Fold3_Model_Result/[Input_Map_Name]. Phase 1 and Phase 2 visualization results (Pymol sessions) are saved in “Phase1” and “Phase2” sub-directory, respectively. You will find generated *.pml files generated to visualize. Please use “pymol -u *.pml” to visualize the final structure detection result. If you want to only see very confident detection results, run “pymol -u *C.pml” using another visualization file named "*C.pml", which only includes confident detections with a probability>=0.9.
@@ -291,7 +287,7 @@ Command line:
 ```
 python3 main.py --mode=2 -F=test_example/REAL_Vote/5WCB.mrc --type=3 --gpu=0 --class=4 -–contour=0.0332
 ```
-If the map grid size is smaller than 1, you also need to specify –-resize=1 to resize the grid size in the command line. This will make the command run slower than the default mode. The example input map is included in [5WCB](https://kiharalab.org/github_data/emap2secplus_data/REAL_Vote), which is a previous example in Emap2sec paper. This example also proves our method can work on EM maps without DNA/RNA. Our output results are saved in [Real_Vote](https://kiharalab.org/github_data/emap2secplus_predict_example/REAL_Vote).
+The example input map is included in [5WCB](https://kiharalab.org/github_data/emap2secplus_data/REAL_Vote), which is a previous example in Emap2sec paper. This example also proves our method can work on EM maps without DNA/RNA. Our output results are saved in [Real_Vote](https://kiharalab.org/github_data/emap2secplus_predict_example/REAL_Vote).
 
 #### 2 Visualize Result
 Results are saved in Predict_Result/REAL/[Input_Map_Name]. Phase 1 and Phase 2 visualization results (Pymol sessions) are saved in “Phase1” and “Phase2” sub-directory, respectively. You will find generated *.pml files generated to visualize. Please use “pymol -u *.pml” to visualize the final structure detection result. If you want to only see very confident detection results, run “pymol -u *C.pml” using another visualization file named "*C.pml", which only includes confident detections with a probability>=0.9.

--- a/main.py
+++ b/main.py
@@ -82,10 +82,7 @@ if __name__ == "__main__":
         from process_map.Reform_Map_Voxel import Reform_Map_Voxel,Reform_Map_Voxel_Final
         output_map=os.path.join(save_path,map_name+".mrc")
         if type==3:
-            if params['resize'] == 1:
-                input_map = Reform_Map_Voxel_Final(input_map, output_map)
-            else:
-                input_map = Reform_Map_Voxel(input_map, output_map)
+            input_map = Reform_Map_Voxel(input_map, output_map)
         else:
             shutil.copy(input_map,output_map)
         from process_map.Build_Map import Build_Map
@@ -147,10 +144,7 @@ if __name__ == "__main__":
 
         output_map = os.path.join(save_path, map_name + ".mrc")
         if type==3:
-            if params['resize'] == 1:
-                input_map = Reform_Map_Voxel_Final(input_map, output_map)
-            else:
-                input_map = Reform_Map_Voxel(input_map, output_map)
+            input_map = Reform_Map_Voxel(input_map, output_map)
         else:
             shutil.copy(input_map,output_map)
         from process_map.Build_Map import Build_Map_WithStructure
@@ -208,10 +202,7 @@ if __name__ == "__main__":
 
         output_map = os.path.join(save_path0, map_name + ".mrc")
         if type==3:
-            if params['resize'] == 1:
-                input_map = Reform_Map_Voxel_Final(input_map, output_map)
-            else:
-                input_map = Reform_Map_Voxel(input_map, output_map)
+            input_map = Reform_Map_Voxel(input_map, output_map)
         else:
             shutil.copy(input_map,output_map)
 
@@ -273,10 +264,7 @@ if __name__ == "__main__":
 
         output_map = os.path.join(save_path0, map_name + ".mrc")
         if type==3:
-            if params['resize'] == 1:
-                input_map = Reform_Map_Voxel_Final(input_map, output_map)
-            else:
-                input_map = Reform_Map_Voxel(input_map, output_map)
+            input_map = Reform_Map_Voxel(input_map, output_map)
         else:
             shutil.copy(input_map,output_map)
         from process_map.Build_Map import Build_Map_WithStructure
@@ -356,10 +344,7 @@ if __name__ == "__main__":
         from process_map.Reform_Map_Voxel import Reform_Map_Voxel, Reform_Map_Voxel_Final
 
         output_map = os.path.join(save_path0, map_name + ".mrc")
-        if params['resize'] == 1:
-            input_map = Reform_Map_Voxel_Final(input_map, output_map)
-        else:
-            input_map = Reform_Map_Voxel(input_map, output_map)
+        input_map = Reform_Map_Voxel(input_map, output_map)
 
         from process_map.Build_Map import Build_Map
 

--- a/ops/argparser.py
+++ b/ops/argparser.py
@@ -35,13 +35,11 @@ import argparse
 
 def argparser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-F',type=str, required=True,help='map path')#File path for our MAINMAST code
+    parser.add_argument('-F',type=str, required=True,help='map path')
     parser.add_argument('--mode',type=int,required=True,help='0: Predict structures for EM MAP\n'
                                                              '1: Predict structures for EM maps with pdb structure\n'
                                                              '2: Predict structure for experimental maps with 4 models\n'
                                                              '3: Predict and evaluate structure for experimental maps with 4 models\n' )
-    parser.add_argument('--resize',type=int,default=0,help="0: resizing maps with numba optimized (some maps size are not supported);\n"
-                                                           "1: resizing maps with scipy (relatively slow but support almost all maps).")
     parser.add_argument('-P',type=str,default="",help="PDB path for evaluating Model's performance")
     parser.add_argument('-M',type=str,default="best_model",help="Trained model path which saved all the trained models")
     parser.add_argument('--type',type=int,help='0:simulated map at 6 A 1: simulated map at 10 A 2: simulated map at 6-10 A 3:experimental map')
@@ -55,10 +53,5 @@ def argparser():
     parser.add_argument('--output_folder',type=str,default="",help='specify a custom folder where results will be stored')
     parser.add_argument('--no_compilation', action='store_false', help='skip automatic compilation before execution')
     args = parser.parse_args()
-    # try:
-    #     import ray,socket
-    #     rayinit()
-    # except:
-    #     print('ray need to be installed')#We do not need this since GAN can't be paralleled.
     params = vars(args)
     return params

--- a/process_map/Reform_Map_Voxel.py
+++ b/process_map/Reform_Map_Voxel.py
@@ -229,6 +229,7 @@ def Reform_Map_Voxel_Final(map_path,new_map_path):
             mrc.print_header()
             mrc_new.print_header()
             mrc_new.close()
+            mrc.close()
             del data
             del data_new
     return new_map_path
@@ -241,8 +242,9 @@ def Reform_Map_Voxel(map_path,new_map_path):
             #assert len(prev_voxel_size)==3
 
             if not(prev_voxel_size['x']==prev_voxel_size['y'] and prev_voxel_size['x']==prev_voxel_size['z']):
-                print("Grid size of different axis is different, please specify --resize=1 in command line to call another slow process to deal with it!")
-                exit(1)
+                mrc.close()
+                print("Grid size of different axis is different, resizing automatically.")
+                return Reform_Map_Voxel_Final(map_path, new_map_path)
             prev_voxel_size=float(prev_voxel_size['x'])
             nx, ny, nz, nxs, nys, nzs, mx, my, mz =\
                 mrc.header.nx, mrc.header.ny, mrc.header.nz, \
@@ -258,8 +260,9 @@ def Reform_Map_Voxel(map_path,new_map_path):
                 shutil.copy(map_path,new_map_path)
                 return new_map_path
             if (prev_voxel_size < 1):
-                print("Grid size is smaller than 1, please specify --resize=1 in command line to call another slow process to deal with it!")
-                exit(1)
+                mrc.close()
+                print("Grid size is smaller than 1, resizing automatically.")
+                return Reform_Map_Voxel_Final(map_path, new_map_path)
             it_val1 = int(np.floor(size[0] * prev_voxel_size))
             it_val2 = int(np.floor(size[1] * prev_voxel_size))
             it_val3 = int(np.floor(size[2] * prev_voxel_size))
@@ -302,6 +305,7 @@ def Reform_Map_Voxel(map_path,new_map_path):
             mrc.print_header()
             mrc_new.print_header()
             mrc_new.close()
+            mrc.close()
             del data
             del data_new
            # del out_1d


### PR DESCRIPTION
The user was previously requested to decide if resize should be 0 (way faster but does not always work) and 1 (slower but works in more scenarios), and if they chose 0 and the required conditions for that to work were not met, the execution halted with an error. Now, instead of that, the user won't have to choose between resize values, the software will always try to run the fastest option, and if the conditions of the input file result in resize=0 not working, resize=1 automatically kicks in to still be able to complete the execution without errors, so the resize value is selected automatically now based on the input file parameters.

Note: This is a breaking change, because every call to Emap2sec+ needed this param before, and now it won't work with it. If you are encountering issues with that param after pulling from the repository, just remove it.