### PR TITLE
Avoid possibility of fold variable not being set

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
             save_path = os.path.join(save_path, indicate)
             mkdir(save_path)
             if type==3:
-                save_path = os.path.join(save_path, "Fold%d_Model_Result" % params.fold)
+                save_path = os.path.join(save_path, "Fold%d_Model_Result" % params['fold'])
                 mkdir(save_path)
             name_split=os.path.split(input_map)
             map_name=name_split[1]
@@ -133,7 +133,7 @@ if __name__ == "__main__":
         batch_size=params['batch_size']
         from evaluate.Predict_Phase1 import Predict_Phase1
         phase1_pred_dict,phase1_pred_file,step1_pred_file=\
-            execute_with_exceptions(Predict_Phase1, save_path,map_name,input_path,indicate,params.fold,batch_size,params)
+            execute_with_exceptions(Predict_Phase1, save_path,map_name,input_path,indicate,params['fold'],batch_size,params)
         #visualize phase 1
         from evaluate.Visualize_Prediction import Visualize_Prediction,Visualize_Confident_Prediction
         Visualize_Prediction(save_path, map_name, step1_pred_file,  factor, 'Phase1')
@@ -170,7 +170,7 @@ if __name__ == "__main__":
             save_path = os.path.join(save_path, indicate)
             mkdir(save_path)
             if type == 3:
-                save_path = os.path.join(save_path, "Fold%d_Model_Result" % params.fold)
+                save_path = os.path.join(save_path, "Fold%d_Model_Result" % params['fold'])
                 mkdir(save_path)
             name_split = os.path.split(input_map)
             map_name = name_split[1]
@@ -209,7 +209,7 @@ if __name__ == "__main__":
         from evaluate.Predict_Phase1 import Predict_Phase1
 
         phase1_pred_dict, phase1_pred_file,step1_pred_file = \
-            execute_with_exceptions(Predict_Phase1, save_path, map_name, input_path, indicate, params.fold, batch_size,params)
+            execute_with_exceptions(Predict_Phase1, save_path, map_name, input_path, indicate, params['fold'], batch_size,params)
 
         Visualize_Prediction_WithStructure(save_path, map_name, step1_pred_file, factor, real_loc_refer, 'Phase1')
         Visualize_Confident_Prediction_WithStructure(save_path, map_name, step1_pred_file, factor, real_loc_refer,

--- a/main.py
+++ b/main.py
@@ -103,9 +103,8 @@ if __name__ == "__main__":
         if not params['output_folder']:
             save_path = os.path.join(save_path, indicate)
             mkdir(save_path)
-            fold = params['fold']  # specify use which fold Model based on real map
             if type==3:
-                save_path = os.path.join(save_path, "Fold%d_Model_Result"%fold)
+                save_path = os.path.join(save_path, "Fold%d_Model_Result" % params.fold)
                 mkdir(save_path)
             name_split=os.path.split(input_map)
             map_name=name_split[1]
@@ -134,7 +133,7 @@ if __name__ == "__main__":
         batch_size=params['batch_size']
         from evaluate.Predict_Phase1 import Predict_Phase1
         phase1_pred_dict,phase1_pred_file,step1_pred_file=\
-            execute_with_exceptions(Predict_Phase1, save_path,map_name,input_path,indicate,fold,batch_size,params)
+            execute_with_exceptions(Predict_Phase1, save_path,map_name,input_path,indicate,params.fold,batch_size,params)
         #visualize phase 1
         from evaluate.Visualize_Prediction import Visualize_Prediction,Visualize_Confident_Prediction
         Visualize_Prediction(save_path, map_name, step1_pred_file,  factor, 'Phase1')
@@ -170,9 +169,8 @@ if __name__ == "__main__":
         if not params['output_folder']:
             save_path = os.path.join(save_path, indicate)
             mkdir(save_path)
-            fold = params['fold']  # specify use which fold Model based on real map
             if type == 3:
-                save_path = os.path.join(save_path, "Fold%d_Model_Result" % fold)
+                save_path = os.path.join(save_path, "Fold%d_Model_Result" % params.fold)
                 mkdir(save_path)
             name_split = os.path.split(input_map)
             map_name = name_split[1]
@@ -211,7 +209,7 @@ if __name__ == "__main__":
         from evaluate.Predict_Phase1 import Predict_Phase1
 
         phase1_pred_dict, phase1_pred_file,step1_pred_file = \
-            execute_with_exceptions(Predict_Phase1, save_path, map_name, input_path, indicate, fold, batch_size,params)
+            execute_with_exceptions(Predict_Phase1, save_path, map_name, input_path, indicate, params.fold, batch_size,params)
 
         Visualize_Prediction_WithStructure(save_path, map_name, step1_pred_file, factor, real_loc_refer, 'Phase1')
         Visualize_Confident_Prediction_WithStructure(save_path, map_name, step1_pred_file, factor, real_loc_refer,


### PR DESCRIPTION
The way this code handles args, up on meeting certain conditions, fold variable will not be properly set when used, causing an error. Using it directly from the args object will solve that issue.

This code needs a complete refactor anyway, it could take up a fraction of what it does now, and become x1000 more readable.
However, it's a big task, so I'm only pushing a fix that will alleviate the specific fold variable issue.